### PR TITLE
Remove unused PIL import

### DIFF
--- a/uploadr.py
+++ b/uploadr.py
@@ -72,7 +72,6 @@ import webbrowser
 import sqlite3 as lite
 import pprint
 import json
-from PIL import Image
 from xml.dom.minidom import parse
 import hashlib
 import fcntl


### PR DESCRIPTION
This line doesn't appear to be used anywhere; ``Image`` isn't utilised.  Having the line present breaks the script for any environment without PIL, such as default Python installs.