### PR TITLE
Add ability to ignore files based on regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Upload a directory of media to Flickr to use as a backup to your local storage.
 * Stores image information locally using a simple SQLite database
 * Creates "Sets" based on the folder name the media is in (getting existing sets from Flickr is managed also)
 * Ignores unwanted directories (like ".picasabackup" for Picasa users)
+* Allows specific files to be ignored (via regular expressions)
 * Convert RAW files (with an external tool)
 
 THIS SCRIPT IS PROVIDED WITH NO WARRANTY WHATSOEVER. PLEASE REVIEW THE SOURCE CODE TO MAKE SURE IT WILL WORK FOR YOUR NEEDS. IF YOU FIND A BUG, PLEASE REPORT IT.

--- a/uploadr.ini
+++ b/uploadr.ini
@@ -53,6 +53,12 @@ TOKEN_PATH = os.path.join(os.path.dirname(sys.argv[0]), ".flickrToken")
 EXCLUDED_FOLDERS = ["@eaDir","#recycle",".picasaoriginals","_ExcludeSync","Corel Auto-Preserve","Originals","Automatisch beibehalten von Corel"]
 
 ################################################################################
+#   List of filename regular expressions you wish to ignore
+#   Regex is used to search the filename (as opposed to matching it completely)
+################################################################################
+IGNORED_REGEX = []
+
+################################################################################
 #   List of file extensions you agree to upload
 ################################################################################
 ALLOWED_EXT = ["jpg","png","avi","mov","mpg","mp4","3gp"]

--- a/uploadr.py
+++ b/uploadr.py
@@ -80,6 +80,7 @@ import errno
 import subprocess
 from sys import stdout
 import itertools
+import re
 
 ##
 ## Read Config from config.ini file
@@ -96,6 +97,7 @@ DB_PATH = eval(config.get('Config','DB_PATH'))
 LOCK_PATH = eval(config.get('Config','LOCK_PATH'))
 TOKEN_PATH = eval(config.get('Config','TOKEN_PATH'))
 EXCLUDED_FOLDERS = eval(config.get('Config','EXCLUDED_FOLDERS'))
+IGNORED_REGEX = [re.compile(regex) for regex in eval(config.get('Config', 'IGNORED_REGEX'))]
 ALLOWED_EXT = eval(config.get('Config','ALLOWED_EXT'))
 RAW_EXT = eval(config.get('Config','RAW_EXT'))
 FILE_MAX_SIZE = eval(config.get('Config','FILE_MAX_SIZE'))
@@ -446,6 +448,8 @@ class Uploadr:
                 if curr_dir in dirnames:
                     dirnames.remove(curr_dir)
             for f in filenames :
+                if any(ignored.search(f) for ignored in IGNORED_REGEX):
+                    continue
                 ext = f.lower().split(".")[-1]
                 if ext in ALLOWED_EXT:
                     fileSize = os.path.getsize( dirpath + "/" + f )


### PR DESCRIPTION
This PR adds the ability to ignore specific files based upon one or more regular expressions matching their filename.  This is useful in preventing unwanted images from being considered for upload, especially when moving the images out of the way is cumbersome or impossible.  

One example is if you have had different sets of images (eg ``my-photo1.jpg`` and ``my-photo1.resized.jpg``), you can thus exclude anything with a regex of ``.resized``.  Another example is if you have specific photos you want to keep private or otherwise from not being uploaded, you could name them specifically in the list of expressions.